### PR TITLE
Replaces occurrences of Symbol(string) to Symbol.for(string)

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -143,9 +143,9 @@ describe("inversify-binding-decorators", () => {
         }
 
         let TYPE = {
-            ThrowableWeapon: Symbol("ThrowableWeapon"),
-            Warrior: Symbol("Warrior"),
-            Weapon: Symbol("Weapon"),
+            ThrowableWeapon: Symbol.for("ThrowableWeapon"),
+            Warrior: Symbol.for("Warrior"),
+            Weapon: Symbol.for("Weapon"),
         };
 
         @provide(TYPE.Weapon)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaces `Symbol(string)` with `Symbol.for(string)`

## Related Issue
[inversify #691](https://github.com/inversify/InversifyJS/issues/691)

## Motivation and Context
[See description of a Symbol](https://developer.mozilla.org/en-US/docs/Glossary/Symbol)

Calling `Symbol()` creates a unique primitive value in the Javascript engine. Without a reference to it, it becomes lost.

```
Symbol('foo') === Symbol('foo')  // false

let key1 = Symbol('foo')
let key2 = Symbol('foo')
let obj = {
    [key1]: 'bar',
    [key2]: 'baz'
}
obj[key1] === 'bar' // true
obj[key2] === 'baz' // true 
```
Object keys created using `Symbol()` are therefore impossible to use without keeping a reference to them. 

Using Symbol.for('foobar') looks up the symbol in the JS registry and returns it if found or creates it if not found. 

## How Has This Been Tested?
This just updates tests in the repo

## Types of changes
- [x] Bug fix / Docs (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (Changes tests)
- [ ] All new and existing tests passed.