### PR TITLE
Update @provideFluent to @fluentProvide in error message and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,18 +294,17 @@ class Shuriken implements Weapon {
 }
 ```
 
-### Using @provideFluent multiple times
+### Using @fluentProvide multiple times
 
-If you try to apply `@provideFluent` multiple times:
+If you try to apply `@fluentProvide` multiple times:
 
 ```ts
 let container = new Container();
-let provideFluent = fluentProvide(container);
 
 const provideSingleton = (identifier: any) => {
-    return provideFluent(identifier)
-    .inSingletonScope()
-    .done();
+    return fluentProvide(identifier)
+        .inSingletonScope()
+        .done();
 };
 
 function shouldThrow() {
@@ -318,7 +317,7 @@ function shouldThrow() {
 
 The library will throw an exception:
 
-> Cannot apply @provideFluent decorator multiple times but is has been used multiple times in Ninja Please use done(true) if you are trying to declare multiple bindings!
+> Cannot apply @fluentProvide decorator multiple times but is has been used multiple times in Ninja Please use done(true) if you are trying to declare multiple bindings!
 
 We throw an exception to ensure that you are are not trying to apply `@fluentProvide` multiple times by mistake.
 
@@ -327,7 +326,7 @@ You can overcome this by passing the `force` argument to `done()`:
 ```ts
 
 const provideSingleton = (identifier: any) => {
-    return provideFluent(identifier)
+    return fluentProvide(identifier)
     .inSingletonScope()
     .done(true); // IMPORTANT!
 };

--- a/src/syntax/provide_done_syntax.ts
+++ b/src/syntax/provide_done_syntax.ts
@@ -26,7 +26,7 @@ class ProvideDoneSyntax implements interfaces.ProvideDoneSyntax {
                     decorate(injectable(), target);
                 } catch (e) {
                     throw new Error(
-                        "Cannot apply @provideFluent decorator multiple times but is has been used " +
+                        "Cannot apply @fluentProvide decorator multiple times but is has been used " +
                         `multiple times in ${target.name} ` +
                         "Please use done(true) if you are trying to declare multiple bindings!"
                     );

--- a/test/decorator/fluent_provide.test.ts
+++ b/test/decorator/fluent_provide.test.ts
@@ -37,7 +37,7 @@ describe("fluentProvide", () => {
         }
 
         expect(shouldThrow).to.throw(
-            "Cannot apply @provideFluent decorator multiple times but is has been used " +
+            "Cannot apply @fluentProvide decorator multiple times but is has been used " +
             "multiple times in Ninja " +
             "Please use done(true) if you are trying to declare multiple bindings!"
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update `@provideFluent` to `@fluentProvide` in error message and `README.md`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#143

## Motivation and Context
`fluentProvide` was updated. It no longer accepts `inversify container` as arguments.
We pass it an identifier and use it directly as a decorator.
Both the example of `README.md` and error message have been incompletely migrated to this change

## How Has This Been Tested?
Just updated `README.md` and error message, but I tried running `npm test` and it was successfully done.

## Types of changes
- [x] Bug fix / Docs (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.