### PR TITLE
Add inRequestScope decorator inversify/InversifyJS/issues/678

### DIFF
--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -15,6 +15,7 @@ namespace interfaces {
 
     export interface ProvideInSyntax<T> extends ProvideDoneSyntax {
         inSingletonScope(): ProvideWhenOnSyntax<T>;
+        inRequestScope(): ProvideWhenOnSyntax<T>;
         inTransientScope(): ProvideWhenOnSyntax<T>;
     }
 

--- a/src/syntax/provide_in_syntax.ts
+++ b/src/syntax/provide_in_syntax.ts
@@ -21,25 +21,29 @@ class ProvideInSyntax<T> implements interfaces.ProvideInSyntax<T> {
     public inSingletonScope(): interfaces.ProvideWhenOnSyntax<T> {
         let bindingWhenOnSyntax = (bind: inversifyInterfaces.Bind, target: any) =>
             this._bindingInSyntax(bind, target).inSingletonScope();
-        let inDoneSyntax = new ProvideDoneSyntax(bindingWhenOnSyntax);
-        let provideWhenSyntax = new ProvideWhenSyntax<T>(bindingWhenOnSyntax, inDoneSyntax);
-        let provideOnSyntax = new ProvideOnSyntax<T>(bindingWhenOnSyntax, inDoneSyntax);
-        return new ProvideWhenOnSyntax(provideWhenSyntax, provideOnSyntax);
+        return this.provideWhenOnSyntax(bindingWhenOnSyntax);
+    }
+
+    public inRequestScope(): interfaces.ProvideWhenOnSyntax<T> {
+        let bindingWhenOnSyntax = (bind: inversifyInterfaces.Bind, target: any) => this._bindingInSyntax(bind, target).inRequestScope();
+        return this.provideWhenOnSyntax(bindingWhenOnSyntax);
     }
 
     public inTransientScope(): interfaces.ProvideWhenOnSyntax<T> {
         let bindingWhenOnSyntax = (bind: inversifyInterfaces.Bind, target: any) => this._bindingInSyntax(bind, target).inTransientScope();
-        let inDoneSyntax = new ProvideDoneSyntax(bindingWhenOnSyntax);
-
-        let provideWhenSyntax = new ProvideWhenSyntax<T>(bindingWhenOnSyntax, inDoneSyntax);
-        let provideOnSyntax = new ProvideOnSyntax<T>(bindingWhenOnSyntax, inDoneSyntax);
-        return new ProvideWhenOnSyntax(provideWhenSyntax, provideOnSyntax);
+        return this.provideWhenOnSyntax(bindingWhenOnSyntax);
     }
 
     public done(force?: boolean) {
         return this._provideDoneSyntax.done(force);
     }
 
+    private provideWhenOnSyntax(bindingWhenOnSyntax: interfaces.BindConstraint) {
+        let inDoneSyntax = new ProvideDoneSyntax(bindingWhenOnSyntax);
+        let provideWhenSyntax = new ProvideWhenSyntax<T>(bindingWhenOnSyntax, inDoneSyntax);
+        let provideOnSyntax = new ProvideOnSyntax<T>(bindingWhenOnSyntax, inDoneSyntax);
+        return new ProvideWhenOnSyntax(provideWhenSyntax, provideOnSyntax);
+    }
 }
 
 export default ProvideInSyntax;

--- a/src/syntax/provide_in_when_on_syntax.ts
+++ b/src/syntax/provide_in_when_on_syntax.ts
@@ -81,6 +81,10 @@ class ProvideInWhenOnSyntax<T> implements interfaces.ProvideInWhenOnSyntax<T>  {
         return this._provideInSyntax.inSingletonScope();
     }
 
+    public inRequestScope(): interfaces.ProvideWhenOnSyntax<T> {
+        return this._provideInSyntax.inRequestScope();
+    }
+
     public inTransientScope(): interfaces.ProvideWhenOnSyntax<T> {
         return this._provideInSyntax.inTransientScope();
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -208,6 +208,10 @@ describe("inversify-binding-decorators", () => {
             return fluentProvide(identifier).inSingletonScope().done();
         };
 
+        let provideRequest = function (identifier: string) {
+            return fluentProvide(identifier).inRequestScope().done();
+        };
+
         let provideTransient = function (identifier: string) {
             return fluentProvide(identifier).inTransientScope().done();
         };
@@ -244,7 +248,7 @@ describe("inversify-binding-decorators", () => {
             }
         }
 
-        @provideTransient(TYPE.ThrowableWeapon)
+        @provideRequest(TYPE.ThrowableWeapon)
         class Shuriken implements ThrowableWeapon {
             private _mark: any;
             public constructor() {

--- a/test/syntax/provide_in_syntax.test.ts
+++ b/test/syntax/provide_in_syntax.test.ts
@@ -19,50 +19,29 @@ describe("ProvideInSyntax", () => {
         sandbox.restore();
     });
 
-    it("Should be able to declare a binding with singleton scope", () => {
+    ["inSingletonScope", "inRequestScope", "inTransientScope"].forEach(scope => {
+        it(`Should be able to declare a binding with ${scope} scope`, () => {
 
-        class Ninja { }
-        let inSingletonScopeExpectation = sinon.expectation.create("inSingletonScope");
-        let mockBindingInSyntax = { inSingletonScope: inSingletonScopeExpectation } as any as inversifyInterfaces.BindingInSyntax<any>;
-        let mockBind = sinon.expectation.create("bind");
-        let bindingInSyntaxFunction =
-            (bind: inversifyInterfaces.Bind, target: any) => {
-                bind<Ninja>("Ninja");
-                return mockBindingInSyntax;
-            };
-        let binding: inversifyInterfaces.Binding<any> = (<any>bindingInSyntaxFunction)._binding;
-        let provideDoneSyntax = new ProvideDoneSyntax(binding as any);
+            class Ninja { }
+            let inScopeExpectation = sinon.expectation.create(scope);
+            let mockBindingInSyntax = { [scope]: inScopeExpectation } as any as inversifyInterfaces.BindingInSyntax<any>;
+            let mockBind = sinon.expectation.create("bind");
+            let bindingInSyntaxFunction =
+                (bind: inversifyInterfaces.Bind, target: any) => {
+                    bind<Ninja>("Ninja");
+                    return mockBindingInSyntax;
+                };
+            let binding: inversifyInterfaces.Binding<any> = (<any>bindingInSyntaxFunction)._binding;
+            let provideDoneSyntax = new ProvideDoneSyntax(binding as any);
 
-        let provideInSyntax = new ProvideInSyntax(bindingInSyntaxFunction, provideDoneSyntax);
+            let provideInSyntax: {[scope: string]: any} = new ProvideInSyntax(bindingInSyntaxFunction, provideDoneSyntax);
 
-        provideInSyntax.inSingletonScope().done()(Ninja);
-        let metadata = Reflect.getMetadata(METADATA_KEY.provide, Reflect)[0];
-        metadata.constraint(mockBind);
-        expect(inSingletonScopeExpectation.calledOnce).to.eql(true, "inSingletonScope was not called exactly once");
-        expect(mockBind.calledWith("Ninja")).to.be.eql(true, "mock bind was not called");
+            provideInSyntax[scope]().done()(Ninja);
+            let metadata = Reflect.getMetadata(METADATA_KEY.provide, Reflect)[0];
+            metadata.constraint(mockBind);
+            expect(inScopeExpectation.calledOnce).to.eql(true, `${scope} was not called exactly once`);
+            expect(mockBind.calledWith("Ninja")).to.be.eql(true, "mock bind was not called");
 
-    });
-    it("Should be able to declare a binding with transient scope", () => {
-
-        class Ninja { }
-        let inTransientScopeExpectation = sinon.expectation.create("inTransientScope");
-        let mockBindingInSyntax = { inTransientScope: inTransientScopeExpectation } as any as inversifyInterfaces.BindingInSyntax<any>;
-        let mockBind = sinon.expectation.create("bind");
-        let bindingInSyntaxFunction =
-            (bind: inversifyInterfaces.Bind, target: any) => {
-                bind<Ninja>("Ninja");
-                return mockBindingInSyntax;
-            };
-        let binding: inversifyInterfaces.Binding<any> = (<any>bindingInSyntaxFunction)._binding;
-        let provideDoneSyntax = new ProvideDoneSyntax(binding as any);
-
-        let provideInSyntax = new ProvideInSyntax(bindingInSyntaxFunction, provideDoneSyntax);
-
-        provideInSyntax.inTransientScope().done()(Ninja);
-        let metadata = Reflect.getMetadata(METADATA_KEY.provide, Reflect)[0];
-        metadata.constraint(mockBind);
-        expect(inTransientScopeExpectation.calledOnce).to.eql(true, "inTransientScope was not called exactly once");
-        expect(mockBind.calledWith("Ninja")).to.be.eql(true, "mock bind was not called");
-
+        });
     });
 });


### PR DESCRIPTION
## Description
This adds `inRequestScope` support in `fluentProvide`.

## Related Issue
inversify/inversify-binding-decorators#212

## How Has This Been Tested?
* Updated tests that included `inSingletonScope` and `inTransientScope` to also include `inRequestScope`. 
* `provide_in_syntax.test.ts` refactored to reduce duplicate code.

## Types of changes
- [ ] Bug fix / Docs (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.