### PR TITLE
exporting constants as METADATA_KEY inversify/InversifyJS/issues/992

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@ import autoProvide from "./utils/auto_wire";
 import provide from "./decorator/provide";
 import fluentProvide from "./decorator/fluent_provide";
 import buildProviderModule from "./factory/module_factory";
+import { METADATA_KEY } from "./constants";
 
 export { fluentProvide };
 export { provide };
 export { autoProvide };
 export { buildProviderModule };
+export { METADATA_KEY };


### PR DESCRIPTION
Like InversifyJS, the 'inversify-binding-decorators' exports constants as METADATA_KEY

## Description
Change `index.ts` to export constants.

## Related Issue
[Export constants](https://github.com/inversify/InversifyJS/issues/992)

## How Has This Been Tested?
Just use the exported METADATA_KEY to delete a metadata using `Reflect.deleteMetadata(metadataKey, target)`

## Types of changes
- [x] Bug fix / Docs (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.