### PR TITLE
feat: default service identifier target to class when omitted

### DIFF
--- a/src/decorator/fluent_provide.ts
+++ b/src/decorator/fluent_provide.ts
@@ -6,9 +6,8 @@ import ProvideDoneSyntax from "../syntax/provide_done_syntax";
 import interfaces from "../interfaces/interfaces";
 import { interfaces as inversifyInterfaces } from "inversify";
 
-function fluentProvide(serviceIdentifier: inversifyInterfaces.ServiceIdentifier<any>) {
-
-  let bindingWhenOnSyntax = (bind: inversifyInterfaces.Bind, target: any) => bind<any>(serviceIdentifier).to(target);
+function fluentProvide(serviceIdentifier?: inversifyInterfaces.ServiceIdentifier<any>) {
+  let bindingWhenOnSyntax = (bind: inversifyInterfaces.Bind, target: any) => bind<any>(serviceIdentifier || target).to(target);
   let bindingConstraintFunction = (bind: inversifyInterfaces.Bind, target: any) => (<any>bindingWhenOnSyntax(bind, target))._binding;
   let provideDoneSyntax = new ProvideDoneSyntax(bindingConstraintFunction);
 

--- a/src/decorator/provide.ts
+++ b/src/decorator/provide.ts
@@ -4,12 +4,11 @@ import interfaces from "../interfaces/interfaces";
 import { METADATA_KEY } from "../constants";
 
 function provide(
-  serviceIdentifier: inversifyInterfaces.ServiceIdentifier<any>,
+  serviceIdentifier?: inversifyInterfaces.ServiceIdentifier<any>,
   force?: boolean
 ) {
 
   return function (target: any) {
-
     const isAlreadyDecorated = Reflect.hasOwnMetadata(inversify_METADATA_KEY.PARAM_TYPES, target);
     const redecorateWithInject = force === true;
 
@@ -30,7 +29,8 @@ function provide(
     }
 
     const currentMetadata: interfaces.ProvideSyntax = {
-      constraint: (bind: inversifyInterfaces.Bind, bindTarget: any) => bind(serviceIdentifier).to(bindTarget),
+      constraint: (bind: inversifyInterfaces.Bind, bindTarget: any) =>
+        bind(serviceIdentifier || bindTarget).to(bindTarget),
       implementationType: target
     };
 

--- a/test/decorator/fluent_provide.test.ts
+++ b/test/decorator/fluent_provide.test.ts
@@ -44,23 +44,14 @@ describe("fluentProvide", () => {
 
     });
 
-    it("Should work if @provide is applied more than once with force flag", () => {
+    it("Should work if @fluentProvide is applied with no arguments", () => {
+      function shouldThrow() {
+        @fluentProvide().inSingletonScope().done()
+        class Ninja {}
+        return Ninja;
+      }
 
-        const provideSingleton = (identifier: any) => {
-            return fluentProvide(identifier)
-                .inSingletonScope()
-                .done(true); // IMPORTANT!
-        };
-
-        function shouldThrow() {
-            @provideSingleton("Ninja")
-            @provideSingleton("SilentNinja")
-            class Ninja { }
-            return Ninja;
-        }
-
-        expect(shouldThrow).not.to.throw();
-
+      expect(shouldThrow).not.to.throw();
     });
 
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -131,6 +131,51 @@ describe("inversify-binding-decorators", () => {
 
     });
 
+    it("Should be able to declare bindings using classes as identifiers on empty provide arguments", () => {
+      let container = new Container();
+
+      @provide()
+      class Katana {
+        public hit() {
+          return "cut!";
+        }
+      }
+
+      @provide()
+      class Shuriken {
+        public throw() {
+          return "hit!";
+        }
+      }
+
+      @provide()
+      class Ninja {
+        public katana: Katana;
+        public shuriken: Shuriken;
+
+        public constructor(katana: Katana, shuriken: Shuriken) {
+          this.katana = katana;
+          this.shuriken = shuriken;
+        }
+
+        public fight() {
+          return this.katana.hit();
+        }
+        public sneak() {
+          return this.shuriken.throw();
+        }
+      }
+
+      container.load(buildProviderModule());
+      let ninja = container.get<Ninja>(Ninja);
+
+      expect(ninja instanceof Ninja).eql(true);
+      expect(ninja.katana instanceof Katana).eql(true);
+      expect(ninja.shuriken instanceof Shuriken).eql(true);
+      expect(ninja.fight()).eql("cut!");
+      expect(ninja.sneak()).eql("hit!");
+    });
+
     it("Should be able to declare bindings using symbols as identifiers", () => {
 
         let container = new Container();
@@ -480,6 +525,51 @@ describe("inversify-binding-decorators", () => {
         expect(wakizashiDojo.warrior.weapon === ninjaShort.weapon).eql(true);
 
 
+    });
+
+    it("Should be able to declare bindings using classes as identifiers on empty provide arguments", () => {
+      let container = new Container();
+
+      @fluentProvide().inSingletonScope().done()
+      class Katana {
+        public hit() {
+          return "cut!";
+        }
+      }
+
+      @fluentProvide().inSingletonScope().done()
+      class Shuriken {
+        public throw() {
+          return "hit!";
+        }
+      }
+
+      @provide()
+      class Ninja {
+        public katana: Katana;
+        public shuriken: Shuriken;
+
+        public constructor(katana: Katana, shuriken: Shuriken) {
+          this.katana = katana;
+          this.shuriken = shuriken;
+        }
+
+        public fight() {
+          return this.katana.hit();
+        }
+        public sneak() {
+          return this.shuriken.throw();
+        }
+      }
+
+      container.load(buildProviderModule());
+      let ninja = container.get<Ninja>(Ninja);
+
+      expect(ninja instanceof Ninja).eql(true);
+      expect(ninja.katana instanceof Katana).eql(true);
+      expect(ninja.shuriken instanceof Shuriken).eql(true);
+      expect(ninja.fight()).eql("cut!");
+      expect(ninja.sneak()).eql("hit!");
     });
 
 });


### PR DESCRIPTION
This PR allows decorators to default to class bindings when omitting the `serviceIdentifier` argument.

I.E:

```typescript
@provide()
class Ninja {
  // ...
}

@fluentProvide().inSingletonScope().done()
class Repository {
  // ...
}
```